### PR TITLE
C-style array syntax --> D-style syntax

### DIFF
--- a/src/undead/dateparse.d
+++ b/src/undead/dateparse.d
@@ -271,7 +271,7 @@ private:
             short value;
         }
 
-        static immutable DateID dateidtab[] =
+        static immutable DateID[] dateidtab =
         [
             {   "january",      DP.month,       1},
             {   "february",     DP.month,       2},


### PR DESCRIPTION
Avoids a warning on 2.068 compiler.