### PR TITLE
Add :xml subPackage for dlangui to use

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -8,3 +8,10 @@ targetPath "bin"
 buildType "unittest" {
     buildOptions "debugMode" "debugInfo" "unittests" "deprecationErrors" "warningsAsErrors"
 }
+excludedSourceFiles "src/undead/xml.d"
+dependency "undead:xml" version="*"
+subPackage {
+    name "xml"
+    targetType "library"
+    sourceFiles "src/undead/xml.d"
+}


### PR DESCRIPTION
Grim isn't too happy that undead isn't building with GDC, this extracts it so it can be used by dlangui until a better solution is found.